### PR TITLE
Fix ItemElvenWeapon layer brightening other layers in 3rd person

### DIFF
--- a/mcp/src/minecraft/net/minecraft/client/renderer/entity/layers/LayerHeldItem.java
+++ b/mcp/src/minecraft/net/minecraft/client/renderer/entity/layers/LayerHeldItem.java
@@ -41,6 +41,12 @@ public class LayerHeldItem implements LayerRenderer<EntityLivingBase>
 
             this.renderHeldItem(entitylivingbaseIn, itemstack1, ItemCameraTransforms.TransformType.THIRD_PERSON_RIGHT_HAND, EnumHandSide.RIGHT);
             this.renderHeldItem(entitylivingbaseIn, itemstack, ItemCameraTransforms.TransformType.THIRD_PERSON_LEFT_HAND, EnumHandSide.LEFT);
+            // Begin Awaken Dreams code
+            if(entitylivingbaseIn != null)
+            {
+            	this.setLightmap(entitylivingbaseIn, null); //if this wasn't set, any item layer rendering after itemstack would render with same lighmap as itemstack
+            }
+            // End Awaken Dreams code
             GlStateManager.popMatrix();
         }
     }
@@ -62,32 +68,39 @@ public class LayerHeldItem implements LayerRenderer<EntityLivingBase>
             boolean flag = handSide == EnumHandSide.LEFT;
             GlStateManager.translate((float)(flag ? -1 : 1) / 16.0F, 0.125F, -0.625F);
             // Begin Awaken Dreams code
-            if(p_188358_2_.getItem() instanceof ItemElvenWeapon)
-            {
-            	int i = p_188358_1_.getBrightnessForRender(0F);
-                float f = i % 65536;
-                float f1 = i / 65536;
-                ItemElvenWeapon itemweapon = (ItemElvenWeapon) p_188358_2_.getItem();
-    			float f2 = (float)(itemweapon.getGlowAmount());
-    			f2 = Math.min(f2, 240F);
-    			if(itemweapon.isGlowing())
-    			{
-    	    		if(f<f1)
-    	    		{
-    	    			f = Math.min(f + f2, 240);
-    	    		}
-    	    		else
-    	    		{
-    	    			f1 = Math.min(f1 + f2, 240);
-    	    		}
-    			}
-                OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, f, f1);  
-            }  
+            this.setLightmap(p_188358_1_, p_188358_2_);
             // End Awaken Dreams code
             Minecraft.getMinecraft().getItemRenderer().renderItemSide(p_188358_1_, p_188358_2_, p_188358_3_, flag);
-            GlStateManager.popMatrix();     
+            GlStateManager.popMatrix();
         }
     }
+    
+    // Begin Awaken Dreams code
+    private void setLightmap(EntityLivingBase entity, ItemStack itemstack)
+    {
+        int i = entity.getBrightnessForRender(0F);
+        float f = i % 65536;
+        float f1 = i / 65536;
+        if(itemstack != null && itemstack.getItem() instanceof ItemElvenWeapon)
+        {
+            ItemElvenWeapon itemweapon = (ItemElvenWeapon) itemstack.getItem();
+			float f2 = (float)(itemweapon.getGlowAmount());
+			f2 = Math.min(f2, 240F);
+			if(itemweapon.isGlowing())
+			{
+	    		if(f<f1)
+	    		{
+	    			f = Math.min(f + f2, 240);
+	    		}
+	    		else
+	    		{
+	    			f1 = Math.min(f1 + f2, 240);
+	    		}
+			}
+        }
+        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, f, f1);
+    }
+    //End Awaken Dreams code
 
     public boolean shouldCombineTextures()
     {


### PR DESCRIPTION
@scribblemaniac We had same issue in third person as we had in first. Layer of elven weapon set lightmap for all item layers (items in both hands, elytra, pumpkin on head...). This fixes the issue. The flickering however came back, and I have no idea why. It happened just like two times out of 50, and it hasn't occur again since I reset the branch hard from uplink master, and made the changes again, still I'd rather have you check it.